### PR TITLE
#33 use include_bytes macro for icon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ include = [
   "Cargo.lock",
   "Cargo.toml",
   "LICENSE",
-  "src/**/*",
-  "static/icon.png",
+  "src/**/*"
 ]
 
 [[bin]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,27 +5,45 @@ mod plot;
 mod popup;
 mod table;
 use gui::NWBView;
+use image::GenericImageView;
 
 fn main() {
-    let icon = image::open("static/icon.png")
-        .expect("Failed to open icon path")
-        .to_rgba8();
-    let (icon_width, icon_height) = icon.dimensions();
+    const ICON: &[u8] = include_bytes!("../static/icon.png");
 
-    let options = eframe::NativeOptions {
-        icon_data: Some(eframe::IconData {
-            rgba: icon.into_raw(),
-            width: icon_width,
-            height: icon_height,
-        }),
-        drag_and_drop_support: true,
-        ..Default::default()
-    };
+    match image::load_from_memory(ICON) {
+        Ok(icon) => {
+            let (icon_width, icon_height) = icon.dimensions();
 
-    eframe::run_native(
-        "NWB View",
-        options,
-        Box::new(|_cc| Box::<NWBView>::default()),
-    )
-    .ok();
+            let options = eframe::NativeOptions {
+                icon_data: Some(eframe::IconData {
+                    rgba: icon.into_rgba8().to_vec(),
+                    width: icon_width,
+                    height: icon_height,
+                }),
+                drag_and_drop_support: true,
+                ..Default::default()
+            };
+
+            eframe::run_native(
+                "NWB View",
+                options,
+                Box::new(|_cc| Box::<NWBView>::default()),
+            )
+            .ok();
+        }
+        Err(error) => {
+            println!("Error raised while loading icon: {}", error);
+            println!("Launching without icon...");
+            let options = eframe::NativeOptions {
+                drag_and_drop_support: true,
+                ..Default::default()
+            };
+            eframe::run_native(
+                "NWB View",
+                options,
+                Box::new(|_cc| Box::<NWBView>::default()),
+            )
+            .ok();
+        }
+    }
 }


### PR DESCRIPTION
To access the static file after the crate is installed via Cargo install, we need to use the [include_str!()](https://doc.rust-lang.org/std/macro.include_str.html) or [include_bytes!()](https://doc.rust-lang.org/std/macro.include_bytes.html) macros to include the contents of the file in your binary at compile time.

There is no need to add it to the include directive of Cargo.toml file.